### PR TITLE
Bump action-get-latest-tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     environment: intg
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-get-latest-tag@v1.5.0
+      - uses: actions-ecosystem/action-get-latest-tag@v1.6.0
         id: get-latest-tag
       - uses: actions-ecosystem/action-bump-semver@v1
         id: bump-semver


### PR DESCRIPTION
This has the github/workspace' is owned by someone else error. The
latest version update should fix it.
